### PR TITLE
fixes Apex Predator's weapon being unselectable

### DIFF
--- a/code/datums/abnormality/_ego_datum/waw.dm
+++ b/code/datums/abnormality/_ego_datum/waw.dm
@@ -394,4 +394,5 @@
 	cost = 50
 
 /datum/ego_datum/weapon/animalism
+	item_path = obj/item/ego_weapon/animalism
 	cost = 50


### PR DESCRIPTION
## About The Pull Request

fixes a tiny error that made Apex Predator's weapon unpickable.

## Why It's Good For The Game
An abnormality with only armor isn't exactly a good thing. Especially when there's a weapon actually coded.
## Changelog
:cl:
fix: did a one line change.
/:cl: